### PR TITLE
Force redraw when progressValue changes

### DIFF
--- a/LinearProgressBar/LinearProgressView.swift
+++ b/LinearProgressBar/LinearProgressView.swift
@@ -35,6 +35,7 @@ class LinearProgressView: UIView {
             } else if (progressValue <= 0) {
                 progressValue = 0
             }
+            setNeedsDisplay()
         }
     }
     


### PR DESCRIPTION
Fix the control so when progressValue changes during runtime, a redraw
is triggered by calling setNeedsDisplay